### PR TITLE
Add pkg-config to have PKG_CHECK_MODULES macro for guile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update
 RUN apt-get install -y git ssh cmake libboost-all-dev cython dh-autoreconf unzip gdb vim
 
 #Install Guile dependecies
-RUN apt-get install -y libgmp-dev libltdl-dev libunistring-dev libffi-dev libgc-dev flex texinfo  libreadline-dev
+RUN apt-get install -y libgmp-dev libltdl-dev libunistring-dev libffi-dev libgc-dev flex texinfo  libreadline-dev pkg-config
 
 ENV HOME /root
 


### PR DESCRIPTION
pkg-config is not installed on `ubuntu:latest` and `guile` configuration fails with:
```
autoreconf: running: /usr/bin/autoconf --force
configure.ac:54: error: possibly undefined macro: PKG_CHECK_MODULES
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
```